### PR TITLE
Add Azure Pipline yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,62 @@
+# flask-open pipeline: includes PR and master pipeline
+# Tests and coverage run for all pipelines
+# build and push PR image runs for PRs (to implement)
+# build and push Release image runs for master (to implement)
+# Release to kubernetes runs for masters (to implement)
+trigger:
+  branches:
+    include:
+      - "*"
+
+name: "$(date:yyyyMMdd)$(rev:.r)"
+
+stages:
+  - stage: runTests
+    displayName: "Run Project Tests"
+    jobs:
+      - job: testRunner1
+        pool:
+          vmImage: "ubuntu-latest"
+        displayName: "Running Tests"
+        condition: or(eq(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.Reason'], 'PullRequest'))
+        steps:
+          - bash: |
+              set -euxo pipefail
+              mkdir coverage
+              chmod -R a+rwx coverage
+            displayName: "Make coverage dir"
+
+          - bash: |
+              set -euxo pipefail
+              ls -la .
+              whoami
+              # Build docker testing image
+              docker build -f deployment/Dockerfile.test -t opinions:testing .
+
+              # Run docker testing image
+              docker run --rm -e OPINIONS_SECRETS_DIR=/tmp -v $(pwd)/coverage:/app/htmlcov opinions:testing
+            displayName: "Build and Run Test Image"
+            condition: succeeded()
+
+          - task: PublishCodeCoverageResults@1
+            displayName: "Publish project code coverage"
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: "./coverage/coverage.xml"
+              reportDirectory: "./coverage"
+            condition: succeeded()
+
+  - stage: buildPushPrImage
+    displayName: "Build and Push Pull Request Image"
+    dependsOn: runTests
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    jobs:
+      - job: prImagePushBuild
+        displayName: "Building PR Image for Dev Release"
+        pool:
+          vmImage: "ubuntu-latest"
+        variables:
+          prImage: "$(Build.Repository.Name)-dev:$(Build.SourceBranchName)-PR$(System.PullRequest.PullRequestId)"
+        steps:
+          - bash: |
+              echo "To Do..."

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ filterwarnings =
   ignore::PendingDeprecationWarning
   ignore::FutureWarning
 
-addopts = --flake8 --cov-report term:skip-covered --cov=opinions --cov-report html --mypy
+addopts = --flake8 --cov-fail-under 80 --cov-report term:skip-covered --cov=opinions --cov-report html --mypy
 
 
 [mypy-flask]


### PR DESCRIPTION
This is a first pass at adding the Azure Pipelines YAML. It should run the tests (testing environment defined in a Dockerfile), and then later (to be added) it should build an image and push it up to a Docker repo.

If we get this project running in a kube cluster, we can also add code here to deploy it.

One element of this PR is perhaps going to be controversial: we define a Docker image in order to run our tests using the same belief that guides us when building deployment infrastructure in general. We would like to provide our Ops team with the easiest possible entrypoint into running and testing this application. Thus, because we're deploying Docker containers, we can do the same with our tests and then no specialized testing environment is required.

Fixes #4 